### PR TITLE
Disable all built in Travis repositories (#800)

### DIFF
--- a/.travis.before_install.sh
+++ b/.travis.before_install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Disable all Travis default repositories 
+sed -i "s/activeByDefault>true</activeByDefault>false</g"  ~/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+before_install: ./.travis.before_install.sh
 script: ./.travis.script.sh
 
 # Run on a dedicated Trusty VM to avoid random problems like "User limit of inotify watches reached"


### PR DESCRIPTION
Travis includes a lot of repositories which are checked for every dependency. Some of the repositories do not even longer exist, e.g. https://nexus.codehaus.org/snapshots

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird-demo/121)

<!-- Reviewable:end -->
