### PR TITLE
Use innerHTML property to set dynamic resource as an image

### DIFF
--- a/demo-web-site/src/main/java/com/vaadin/hummingbird/demo/website/DynamicResourcesView.java
+++ b/demo-web-site/src/main/java/com/vaadin/hummingbird/demo/website/DynamicResourcesView.java
@@ -61,7 +61,8 @@ public final class DynamicResourcesView extends SimpleView {
         Button button = new Button("Generate image");
 
         button.addClickListener(event -> {
-            image.setAttribute("data", createResource());
+            // image.setAttribute("data", createResource());
+            updateImage();
         });
 
         add(button);
@@ -83,12 +84,22 @@ public final class DynamicResourcesView extends SimpleView {
     }
 
     private void createImage() {
-        image = new Element("object");
-        image.setAttribute("type", "image/svg+xml");
-        image.getStyle().set("display", "block");
-        image.setAttribute("data", createResource());
+        image = new Element("div");
+        // image.setAttribute("type", "image/svg+xml");
+        // image.getStyle().set("display", "block");
+        // image.setAttribute("data", createResource());
+        updateImage();
+
         getElement().appendChild(image);
 
+    }
+
+    private void updateImage() {
+        StreamResource resource = createResource();
+        image.setAttribute("non-existent", resource);
+        image.setProperty("innerHTML",
+                "<object type='image/svg+xml' style='display:block' data='"
+                        + image.getAttribute("non-existent") + "'></object>");
     }
 
     private StreamResource createResource() {


### PR DESCRIPTION
For some reasons EDGE doesn't show svg image created from the server
side. So instead of creating a real "object" element it's set as
"innerHTML" property for its "fake" parent element.

Fixes #184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird-demo/206)
<!-- Reviewable:end -->
