### PR TITLE
Fixed Chrome-related issues for demo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 .settings
 .classpath
 target
-*/driver
-*/selenium_standalone_zips
+driver
+driver_zips
 
 */.project
 */.settings

--- a/demo-hello-world-template/pom.xml
+++ b/demo-hello-world-template/pom.xml
@@ -1,94 +1,110 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.vaadin.hummingbird.demo</groupId>
-		<artifactId>hummingbird-demo-project</artifactId>
-		<version>0.0.21-SNAPSHOT</version>
-	</parent>
-	<name>Hello World using Template API</name>
-	<artifactId>demo-hello-world-template</artifactId>
-	<packaging>war</packaging>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin.hummingbird.demo</groupId>
+        <artifactId>hummingbird-demo-project</artifactId>
+        <version>0.0.21-SNAPSHOT</version>
+    </parent>
+    <name>Hello World using Template API</name>
+    <artifactId>demo-hello-world-template</artifactId>
+    <packaging>war</packaging>
 
-	<properties>
-		<node.version>v6.2.0</node.version>
-		<npm.version>3.9.3</npm.version>
-		<js.working.directory>src/main/webapp/js</js.working.directory>
-	</properties>
+    <properties>
+        <node.version>v6.2.0</node.version>
+        <npm.version>3.9.3</npm.version>
+        <js.working.directory>src/main/webapp/js</js.working.directory>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>hummingbird</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin.hummingbird.demo</groupId>
-			<artifactId>demo-test-util</artifactId>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>hummingbird</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin.hummingbird.demo</groupId>
+            <artifactId>demo-test-util</artifactId>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.eirslett</groupId>
-				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.0</version>
-				<configuration>
-					<nodeVersion>${node.version}</nodeVersion>
-					<npmVersion>${npm.version}</npmVersion>
-				</configuration>
-				<executions>
-					<execution>
-						<id>install-node-and-npm</id>
-						<goals>
-							<goal>install-node-and-npm</goal>
-							<goal>npm</goal> <!-- runs 'install' by default -->
-							<goal>bower</goal> <!-- runs 'install' by default -->
-						</goals>
-						<configuration>
-							<workingDirectory>${js.working.directory}</workingDirectory>
-							<arguments>-f install</arguments>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-war-plugin</artifactId>
-				<configuration>
-					<webResources>
-						<resource>
-							<!-- this is relative to the pom.xml directory -->
-							<directory>${js.working.directory}</directory>
-							<include>bower_components/**</include>
-						</resource>
-					</webResources>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>com.lazerycode.selenium</groupId>
-				<artifactId>driver-binary-downloader-maven-plugin</artifactId>
-				<version>1.0.10</version>
-				<configuration>
-					<!-- root directory that downloaded driver binaries will
-                        be stored in -->
-					<onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
-					<rootStandaloneServerDirectory>driver</rootStandaloneServerDirectory>
-					<customRepositoryMap>../repo.xml</customRepositoryMap>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>selenium</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.0</version>
+                <configuration>
+                    <nodeVersion>${node.version}</nodeVersion>
+                    <npmVersion>${npm.version}</npmVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-node-and-npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                            <goal>npm</goal> <!-- runs 'install' by default -->
+                            <goal>bower</goal> <!-- runs 'install' by default -->
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${js.working.directory}</workingDirectory>
+                            <arguments>-f install</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <!-- this is relative to the pom.xml directory -->
+                            <directory>${js.working.directory}</directory>
+                            <include>bower_components/**</include>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                        <version>1.0.10</version>
+                        <configuration>
+                            <!-- root directory that downloaded driver binaries will
+                                be stored in -->
+                            <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>../driver</rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>../driver_zips</downloadedZipFileDirectory>
+                            <customRepositoryMap>../repo.xml</customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/demo-hello-world-template/src/test/java/com/vaadin/hummingbird/demo/helloworld/element/HelloWorldIT.java
+++ b/demo-hello-world-template/src/test/java/com/vaadin/hummingbird/demo/helloworld/element/HelloWorldIT.java
@@ -17,14 +17,11 @@ package com.vaadin.hummingbird.demo.helloworld.element;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.hummingbird.demo.testutil.AbstractChromeTest;
-import com.vaadin.hummingbird.testcategory.ChromeTests;
 import com.vaadin.testbench.By;
 
-@Category(ChromeTests.class)
 public class HelloWorldIT extends AbstractChromeTest {
 
     @Test

--- a/demo-test-util/src/main/java/com/vaadin/hummingbird/demo/testutil/AbstractChromeTest.java
+++ b/demo-test-util/src/main/java/com/vaadin/hummingbird/demo/testutil/AbstractChromeTest.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.hummingbird.demo.testutil;
 
-import com.vaadin.hummingbird.testutil.SingleBrowserTest;
+import com.vaadin.hummingbird.testutil.ChromeBrowserTest;
 
 /**
  * TestBench test class which sets up URLs according to how demo projects are
@@ -23,7 +23,7 @@ import com.vaadin.hummingbird.testutil.SingleBrowserTest;
  *
  * @author Vaadin Ltd
  */
-public abstract class AbstractChromeTest extends SingleBrowserTest {
+public abstract class AbstractChromeTest extends ChromeBrowserTest {
 
     @Override
     protected String getTestPath() {


### PR DESCRIPTION
Closes #214 

I've failed to avoid copy-paste related to `driver-binary-downloader-maven-plugin`: if I put that configuration into parent pom, plugin goes wild, prints same log strings numerous times, download irrelevant drivers and fails.
So, the idea is to have a single folder with drivers and copy paste the configuration in every module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird-demo/216)
<!-- Reviewable:end -->
