### PR TITLE
Correct Angular template model usage.

### DIFF
--- a/demo-addressbook/src/main/java/com/vaadin/flow/demo/addressbook/ui/Addressbook.java
+++ b/demo-addressbook/src/main/java/com/vaadin/flow/demo/addressbook/ui/Addressbook.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.demo.addressbook.backend.ContactService;
 import com.vaadin.flow.nodefeature.TemplateMap;
 import com.vaadin.flow.router.LocationChangeEvent;
 import com.vaadin.flow.router.View;
-import com.vaadin.flow.template.model.TemplateModel;
+import com.vaadin.flow.template.angular.model.TemplateModel;
 import com.vaadin.server.Command;
 import com.vaadin.ui.AngularTemplate;
 

--- a/demo-addressbook/src/main/java/com/vaadin/flow/demo/addressbook/ui/ContactForm.java
+++ b/demo-addressbook/src/main/java/com/vaadin/flow/demo/addressbook/ui/ContactForm.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.dom.impl.TemplateElementStateProvider;
 import com.vaadin.flow.html.Input;
 import com.vaadin.flow.nodefeature.TemplateOverridesMap;
 import com.vaadin.flow.template.angular.ElementTemplateNode;
-import com.vaadin.flow.template.model.TemplateModel;
+import com.vaadin.flow.template.angular.model.TemplateModel;
 import com.vaadin.server.Command;
 import com.vaadin.ui.AngularTemplate;
 import com.vaadin.ui.HasElement;

--- a/demo-hello-world-template/src/main/webapp/bower.json
+++ b/demo-hello-world-template/src/main/webapp/bower.json
@@ -16,6 +16,6 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#v2.0.0-rc.3",
-    "paper-input": "2.0-preview"
+    "paper-input": "git@github.com:PolymerElements/paper-input.git#ec5fe6497711fb4987f294b67240c45da2959941"
   }
 }

--- a/demo-web-site/src/main/java/com/vaadin/flow/demo/website/MainLayout.java
+++ b/demo-web-site/src/main/java/com/vaadin/flow/demo/website/MainLayout.java
@@ -21,7 +21,7 @@ import java.util.List;
 import com.vaadin.annotations.StyleSheet;
 import com.vaadin.flow.router.LocationChangeEvent;
 import com.vaadin.flow.router.View;
-import com.vaadin.flow.template.model.TemplateModel;
+import com.vaadin.flow.template.angular.model.TemplateModel;
 import com.vaadin.ui.AngularTemplate;
 
 /**


### PR DESCRIPTION
Now there are two Template models: for polymer components and for
angular components. Demos are updated to use correct template model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-demo/243)
<!-- Reviewable:end -->
