### PR TITLE
Increase maximun allowed war size

### DIFF
--- a/demo-validator/pom.xml
+++ b/demo-validator/pom.xml
@@ -26,7 +26,7 @@
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                     <systemPropertyVariables>
-                        <projectBaseDirectory>${project.basedir}/..</projectBaseDirectory>
+                        <projectBaseDirectory>${project.rootdir}</projectBaseDirectory>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/demo-validator/src/test/java/com/vaadin/flow/demo/validator/WarSizesIT.java
+++ b/demo-validator/src/test/java/com/vaadin/flow/demo/validator/WarSizesIT.java
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class WarSizesIT {
     private static final String PROJECT_BASE_DIRECTORY_PROPERTY_NAME = "projectBaseDirectory";
-    // 20 MB
-    private static final long MAX_ALLOWED_WAR_SIZE_BYTES = 20 * 1024 * 1024;
+    // 35 MB
+    private static final long MAX_ALLOWED_WAR_SIZE_BYTES = 35 * 1024 * 1024;
 
     @Test
     public void checkWarSizes() throws Exception {


### PR DESCRIPTION
Space increased due to increased space of dependencies: bower and Maven ones for two artifacts.
New flow-maven-plugin will also add more bower files, since there are no way to determine which files are used by the Framework user now.

That's why the easiest thing we can do now is to allow the wars to be bigger for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-demo/386)
<!-- Reviewable:end -->
