### PR TITLE
Correct applicaiton logic after the latest changes in Flow

### DIFF
--- a/demo-dynamic-menu/src/main/java/com/vaadin/flow/demo/dynamicmenu/MainLayout.java
+++ b/demo-dynamic-menu/src/main/java/com/vaadin/flow/demo/dynamicmenu/MainLayout.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.demo.dynamicmenu;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.RouterLayout;
 
 /**
@@ -27,7 +29,8 @@ import com.vaadin.flow.router.RouterLayout;
  * @author Vaadin Ltd
  */
 @StyleSheet("css/site.css")
-public final class MainLayout extends Div implements RouterLayout {
+public final class MainLayout extends Div
+        implements RouterLayout, BeforeEnterObserver {
 
     private final Div contentHolder = new Div();
     private final Menu menu;
@@ -46,5 +49,19 @@ public final class MainLayout extends Div implements RouterLayout {
     @Override
     public void showRouterLayoutContent(HasElement content) {
         contentHolder.getElement().appendChild(content.getElement());
+    }
+
+    /**
+     * Called when the location changes so the menu can be updated based on the
+     * currently shown view.
+     *
+     * @param event
+     *            before navigation change event
+     */
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        int categoryId = CategoryView.getCategoryId(event.getLocation());
+        int productId = ProductView.getProductId(event.getLocation());
+        menu.updateSelection(categoryId, productId);
     }
 }

--- a/demo-dynamic-menu/src/main/java/com/vaadin/flow/demo/dynamicmenu/Menu.java
+++ b/demo-dynamic-menu/src/main/java/com/vaadin/flow/demo/dynamicmenu/Menu.java
@@ -24,8 +24,6 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.demo.dynamicmenu.backend.DataService;
 import com.vaadin.flow.demo.dynamicmenu.data.Category;
 import com.vaadin.flow.demo.dynamicmenu.data.Product;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 
 /**
  * Menu displaying categories as groups and products as items in the groups.
@@ -33,7 +31,7 @@ import com.vaadin.flow.router.BeforeEnterObserver;
  * @author Vaadin
  * @since
  */
-public final class Menu extends Div implements BeforeEnterObserver {
+public final class Menu extends Div {
 
     private Map<Integer, CategoryMenuItem> categories = new HashMap<>();
 
@@ -53,16 +51,15 @@ public final class Menu extends Div implements BeforeEnterObserver {
     }
 
     /**
-     * Called when the location changes so the menu can be updated based on the
-     * currently shown view.
+     * Updates menu selection with the given {@code categoryId} and
+     * {@code productId}.
      *
-     * @param event
-     *         before navigation change event
+     * @param categoryId
+     *            the category id
+     * @param productId
+     *            the product id
      */
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        int categoryId = CategoryView.getCategoryId(event.getLocation());
-        int productId = ProductView.getProductId(event.getLocation());
+    public void updateSelection(int categoryId, int productId) {
         if (categoryId == -1 && productId != -1) {
             Optional<Product> p = DataService.get().getProductById(productId);
             if (p.isPresent()) {


### PR DESCRIPTION
BeforeEnterObservers that are not children of the navigation target or are not
parent layouts for the navigation target are not notificed anymore.
Menu instance is a child of the parent layout and can't be notified anymore
when navigation is done to its sibling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-demo/422)
<!-- Reviewable:end -->
