### PR TITLE
Exclude saucelabs from testbench 6 beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,10 @@
             </snapshots>
         </repository>
         <repository>
+            <id>vaadin-addons</id>
+            <url>http://maven.vaadin.com/vaadin-addons</url>
+        </repository>
+        <repository>
             <id>flow-prerelease</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
@@ -127,6 +131,15 @@
                 <groupId>com.vaadin.flow.demo</groupId>
                 <artifactId>demo-test-util</artifactId>
                 <version>${project.version}</version>
+
+                <!-- Remove this when testbench removes saucelabs or fixes the
+                dependency to not bring in google-collections -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>vaadin-testbench-core</artifactId>
+                    </exclusion>
+                </exclusions>
                 <scope>test</scope>
             </dependency>
 
@@ -157,6 +170,21 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
+        </dependency>
+
+        <!-- Remove this when testbench removes saucelabs or fixes the
+        dependency to not bring in google-collections -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-core</artifactId>
+            <version>6.0.0.beta3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.saucelabs</groupId>
+                    <artifactId>ci-sauce</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,6 @@
             </snapshots>
         </repository>
         <repository>
-            <id>vaadin-addons</id>
-            <url>http://maven.vaadin.com/vaadin-addons</url>
-        </repository>
-        <repository>
             <id>flow-prerelease</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
@@ -136,8 +132,8 @@
                 dependency to not bring in google-collections -->
                 <exclusions>
                     <exclusion>
-                        <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-testbench-core</artifactId>
+                        <groupId>com.google.collections</groupId>
+                        <artifactId>google-collections</artifactId>
                     </exclusion>
                 </exclusions>
                 <scope>test</scope>
@@ -170,21 +166,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
-        </dependency>
-
-        <!-- Remove this when testbench removes saucelabs or fixes the
-        dependency to not bring in google-collections -->
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-testbench-core</artifactId>
-            <version>6.0.0.beta3</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.saucelabs</groupId>
-                    <artifactId>ci-sauce</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
It brings in google-collections which is a
deprecated predecessor of guava

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-demo/425)
<!-- Reviewable:end -->
