### PR TITLE
Verify flow-maven-plugin no bundling mode

### DIFF
--- a/demo-contact-form/pom.xml
+++ b/demo-contact-form/pom.xml
@@ -121,6 +121,8 @@
                                 </goals>
                                 <configuration>
                                     <transpileOutputDirectory>${transpilation.output}</transpileOutputDirectory>
+                                    <!-- Verify that Flow is able to build and start an app in the production mode without bundling -->
+                                    <bundle>false</bundle>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Disable bundling for one of the demos to ensure that flow-maven-plugin and Flow app work